### PR TITLE
Detect if missing must_be_set keys in kconfig file

### DIFF
--- a/kcc/cli.py
+++ b/kcc/cli.py
@@ -15,7 +15,8 @@ from .defaults import MUST_BE_SET, MUST_BE_SET_OR_MODULE, MUST_BE_UNSET
 
 def run(*,
         config_file: str = '',
-        query: bool = False):
+        query: bool = False,
+        missings: bool = False):
     if query:
         must_be_set, must_be_set_or_module, must_be_unset = \
                 KernelSelfProtectionProject()
@@ -24,11 +25,14 @@ def run(*,
         must_be_unset.update(MUST_BE_UNSET)
 
     kconfig = Kconfig.default()
-    results = kconfig.check(config_file)
-    if not results:
+    results, missing_keys = kconfig.check(config_file)
+    if not results and not missing_keys:
         return
     for opt, msg in results.items():
         print(opt, msg)
+    if missings:
+        for key in missing_keys:
+            print(key)
     return 1
 
 def cli() -> None:
@@ -36,6 +40,7 @@ def cli() -> None:
     parser.add_argument('config_file', nargs='?', type=argparse.FileType('r'),
             default=sys.stdin)
     parser.add_argument('--query', default=False, action='store_true')
+    parser.add_argument('--missings', default=False, action='store_true')
     args = parser.parse_args()
     ret = run(**vars(args))
     args.config_file.close()


### PR DESCRIPTION
Display if any of the keys in MUST_BE_SET Dict is not contained in the
kernel config file.