### PR TITLE
drop extra DEVMEM depends restriction

### DIFF
--- a/kcc/defaults.py
+++ b/kcc/defaults.py
@@ -18,8 +18,6 @@ MUST_BE_SET["CONFIG_CC_STACKPROTECTOR"] = "Stack Protector is for buffer overflo
 MUST_BE_SET["CONFIG_STACKPROTECTOR"] = "Stack Protector is for buffer overflow detection and hardening"
 
 MUST_BE_UNSET["CONFIG_DEVMEM"] = "/dev/mem is dangerous and has no legitimate users anymore"
-MUST_BE_SET["CONFIG_STRICT_DEVMEM"] = "/dev/mem is dangerous and access must be strictly limited"
-MUST_BE_SET["CONFIG_IO_STRICT_DEVMEM"] = "/dev/mem is dangerous and access must be strictly limited"
 
 MUST_BE_SET["CONFIG_DEBUG_CREDENTIALS"] = "Needed to protect against targeted corruption by rootkits"
 MUST_BE_SET["CONFIG_DEBUG_NOTIFIERS"] = "Needed to protect against targeted corruption by rootkits"


### PR DESCRIPTION
KCC recommends to disable DEVMEM and set STRICT_DEVMEM and
IO_STRICT_DEVMEM, but from [1]
```
> # Do not allow direct physical memory access (but if you must have it, at least enable STRICT mode...)
> # CONFIG_DEVMEM is not set
> CONFIG_STRICT_DEVMEM=y
> CONFIG_IO_STRICT_DEVMEM=y
```
From lib/Kconfig.debug file, STRICT_DEVMEM depends on MMU && DEVMEM,
and IO_STRICT_DEVMEM depends on STRICT_DEVMEM.

On Linux commit https://github.com/torvalds/linux/commit/045f6d7942be248fbda6e85b2393f2735695ed39
some messed up configurations were fixed and for kernels > 5.6,
when DEVMEM "is not set", STRICT_DEVMEM is showed as "is not set"
in the kernel config file. This brings a false positive error
message for kernels >= 5.7.

As STRICT_DEVMEM and IO_STRICT_DEVMEM are not set when DEVMEN
"is not set", let's remove them from KCC

[1] https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project/Recommended_Settings